### PR TITLE
Add missing link with libintl

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.2.0)
 
 project(fcitx-qt5)
 
@@ -16,6 +16,7 @@ include(ECMPackageConfigHelpers)
 include(ECMSetupVersion)
 include(ECMGenerateHeaders)
 
+find_package(Intl REQUIRED)
 find_package(Qt5 ${REQUIRED_QT_VERSION} CONFIG REQUIRED Core DBus Widgets)
 find_package(Qt5Gui ${REQUIRED_QT_VERSION} REQUIRED Private)
 find_package(XKBCommon 0.5.0 REQUIRED COMPONENTS XKBCommon)

--- a/widgetsaddons/CMakeLists.txt
+++ b/widgetsaddons/CMakeLists.txt
@@ -40,6 +40,7 @@ set(fcitxqtwidgetsaddons_INCLUDE_DIRS
     ${CMAKE_CURRENT_BINARY_DIR}
     ${CMAKE_CURRENT_SOURCE_DIR}
     ${FCITX_UTILS_INCLUDE_DIRS}
+    ${Intl_INCLUDE_DIRS}
 )
 
 add_library(FcitxQt5WidgetsAddons SHARED ${widgetsaddons_SOURCES})
@@ -65,6 +66,7 @@ target_link_libraries(FcitxQt5WidgetsAddons
     PRIVATE
         ${FCITX_UTILS_LIBRARIES}
         ${FCITX_CONFIG_LIBRARIES}
+        ${Intl_LIBRARIES}
 )
 
 install(TARGETS FcitxQt5WidgetsAddons EXPORT FcitxQt5WidgetsAddonsTargets LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}")


### PR DESCRIPTION
WidgetAddons uses dgettext(3), so it must link with libintl.
