### PR TITLE
add flatpak support

### DIFF
--- a/dbusaddons/fcitxqtconnection.cpp
+++ b/dbusaddons/fcitxqtconnection.cpp
@@ -194,7 +194,9 @@ int FcitxQtConnectionPrivate::displayNumber() {
             ++pos;
             int pos2 = display.indexOf('.', pos);
             if (pos2 > 0) {
-                displayNumber = display.mid(pos, pos2 - pos);
+                // Flatpak: use host display number
+                ++pos2;
+                displayNumber = display.mid(pos2);
             } else {
                 displayNumber = display.mid(pos);
             }
@@ -217,14 +219,21 @@ const QString& FcitxQtConnectionPrivate::socketFile()
     if (!m_socketFile.isEmpty())
         return m_socketFile;
 
-    QString filename = QString("%1-%2").arg(QString::fromLatin1(QDBusConnection::localMachineId())).arg(displayNumber());
-
-    QString home = QString::fromLocal8Bit(qgetenv("XDG_CONFIG_HOME"));
-    if (home.isEmpty()) {
-        home = QDir::homePath().append(QLatin1Literal("/.config"));
+    // Flatpak: use host dbus file for fcitx
+    QString configDir = qgetenv("FCITX_USER_CONFIG_DIR");
+    if (!configDir.isEmpty()) {
+        QString home = qgetenv("HOME");
+        QString machineID = QString::fromLatin1(QDBusConnection::localMachineId());
+        QString filename = QString("%1-%2").arg(machineID).arg(displayNumber());
+        m_socketFile = QString("%1/%2/dbus/%3").arg(home).arg(configDir).arg(filename);
+    } else {
+        QString filename = QString("%1-%2").arg(QString::fromLatin1(QDBusConnection::localMachineId())).arg(displayNumber());
+        QString home = QString::fromLocal8Bit(qgetenv("XDG_CONFIG_HOME"));
+        if (home.isEmpty()) {
+            home = QDir::homePath().append(QLatin1Literal("/.config"));
+        }
+        m_socketFile = QString("%1/fcitx/dbus/%2").arg(home).arg(filename);
     }
-    m_socketFile = QString("%1/fcitx/dbus/%2").arg(home).arg(filename);
-
     return m_socketFile;
 }
 
@@ -253,6 +262,14 @@ QString FcitxQtConnectionPrivate::address()
     if (sz != addrlen + 2 * sizeof(pid_t) + 1)
         return QString();
 
+    addr = QLatin1String(buffer);
+
+    // Flatpak: skip pid check, may add a config option is better
+    QString configDir = qgetenv("FCITX_USER_CONFIG_DIR");
+    if (!configDir.isEmpty()) {
+        return addr;
+    }
+
     /* skip '\0' */
     p++;
     pid_t *ppid = (pid_t*) p;
@@ -262,8 +279,6 @@ QString FcitxQtConnectionPrivate::address()
     if (!_pid_exists(daemonpid)
         || !_pid_exists(fcitxpid))
         return QString();
-
-    addr = QLatin1String(buffer);
 
     return addr;
 }


### PR DESCRIPTION
主要处理三个问题：
1. Flatpak的daemon用的是host的DISPLAY=:0作为dbus的servername的，但是在flatpak的sandbox里面被换成:99.0，解析出来的servername不对。
2. XDG_CONFIG_HOME被flatpak换掉了，于是用FCITX_USER_CONFIG_DIR+HOME来代替，勉强可以使用吧，如果用户改host的 XDG_CONFIG_HOME还是会挂掉。其实直接传递FCITX_DBUS_ADDRESS 应该也可以，不过这个东西目前还不清楚怎么通过flatpak传递给sandbox，每个用户的这个值都是不同的。
3. PID检查神马的，当然是通过不了啦:P。另外这个检查的写法会导致内存对齐错误，如果内核开启的对齐检查就会输出很多错误日志。

这个PR仅供参考，在deepin的环境下测试可以使用。