### PR TITLE
Add possibility to build Qt plugin statically and to specify Qt plugin directory

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,8 @@ find_package(ECM 1.4.0 REQUIRED NO_MODULE)
 set(CMAKE_MODULE_PATH ${ECM_MODULE_PATH} ${ECM_KDE_MODULE_DIR} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
 option(ENABLE_LIBRARY "Qt library" On)
+option(STATIC_PLUGIN "Build Qt plugin statically" Off)
+option(PLUGINDIR "Path to the plugin directory")
 
 include(GNUInstallDirs)
 include(FeatureSummary)

--- a/platforminputcontext/CMakeLists.txt
+++ b/platforminputcontext/CMakeLists.txt
@@ -24,7 +24,11 @@ qt5_add_dbus_interface(plugin_SRCS org.fcitx.Fcitx.InputContext1.xml inputcontex
 qt5_add_dbus_interface(plugin_SRCS org.fcitx.Fcitx.InputMethod.xml inputmethodproxy)
 qt5_add_dbus_interface(plugin_SRCS org.fcitx.Fcitx.InputMethod1.xml inputmethod1proxy)
 
+if (STATIC_PLUGIN)
+add_library(fcitxplatforminputcontextplugin STATIC ${plugin_SRCS})
+else()
 add_library(fcitxplatforminputcontextplugin MODULE ${plugin_SRCS})
+endif()
 set_target_properties(fcitxplatforminputcontextplugin PROPERTIES
                          AUTOMOC TRUE
                          COMPILE_FLAGS "-fvisibility=hidden"
@@ -39,8 +43,14 @@ target_link_libraries(fcitxplatforminputcontextplugin
                           Qt5::DBus
                           XKBCommon::XKBCommon
                          )
+if (STATIC_PLUGIN)
+target_compile_definitions(fcitxplatforminputcontextplugin PRIVATE QT_STATICPLUGIN)
+endif()
 
 include(ECMQueryQmake)
+if (PLUGINDIR)
+set(CMAKE_INSTALL_QTPLUGINDIR ${PLUGINDIR})
+endif()
 if (NOT CMAKE_INSTALL_QTPLUGINDIR)
 query_qmake(CMAKE_INSTALL_QTPLUGINDIR QT_INSTALL_PLUGINS)
 endif()


### PR DESCRIPTION
I'm trying to get linking of input plugins in tdesktop without patching of Qt. Currently it uses [a way old fcitx](https://github.com/desktop-app/fcitx) and integrates it [using a Qt patch](https://github.com/desktop-app/patches/blob/master/qtbase_5_12_8.diff#L504). In this PR I added everything that is needed to build tdesktop with upstream fcitx-qt5.