### PR TITLE
CMakeLists.txt: respect $sysroot in generated cmake config

### DIFF
--- a/dbusaddons/CMakeLists.txt
+++ b/dbusaddons/CMakeLists.txt
@@ -51,7 +51,8 @@ generate_export_header(FcitxQt5DBusAddons BASE_NAME FcitxQtDBusAddons)
 add_library(FcitxQt5::DBusAddons ALIAS FcitxQt5DBusAddons)
 
 target_include_directories(FcitxQt5DBusAddons PUBLIC "$<BUILD_INTERFACE:${fcitxqtdbusaddons_INCLUDE_DIRS}>")
-target_include_directories(FcitxQt5DBusAddons INTERFACE "$<INSTALL_INTERFACE:${FcitxQt5_INCLUDE_INSTALL_DIR}/FcitxQtDBusAddons>")
+target_include_directories(FcitxQt5DBusAddons
+                           INTERFACE $<INSTALL_INTERFACE:include/FcitxQt5/FcitxQtDBusAddons>)
 
 set_target_properties(FcitxQt5DBusAddons
                       PROPERTIES VERSION 1.0

--- a/widgetsaddons/CMakeLists.txt
+++ b/widgetsaddons/CMakeLists.txt
@@ -52,7 +52,8 @@ generate_export_header(FcitxQt5WidgetsAddons BASE_NAME FcitxQtWidgetsAddons)
 add_library(FcitxQt5::WidgetsAddons ALIAS FcitxQt5WidgetsAddons)
 
 target_include_directories(FcitxQt5WidgetsAddons PUBLIC "$<BUILD_INTERFACE:${fcitxqtwidgetsaddons_INCLUDE_DIRS}>")
-target_include_directories(FcitxQt5WidgetsAddons INTERFACE "$<INSTALL_INTERFACE:${FcitxQt5_INCLUDE_INSTALL_DIR}/FcitxQtWidgetsAddons>")
+target_include_directories(FcitxQt5WidgetsAddons
+                           INTERFACE $<INSTALL_INTERFACE:include/FcitxQt5/FcitxQtWidgetsAddons>)
 
 set_target_properties(FcitxQt5WidgetsAddons
                       PROPERTIES VERSION 1.0


### PR DESCRIPTION
Current CMakeLists.txt generates Fcitx*Targets.cmake,
with INTERFACE_INCLUDE_DIRECTORIES set to static value, that doesn't
respect CMAKE_FIND_ROOT_PATH when cross compile for other platform.

Use the documented: `$<INSTALL_INTERFACE:include/mylib>` [1] instead.

[1]: https://cmake.org/cmake/help/v3.0/command/target_include_directories.html