### PR TITLE
Allow building with QT_NO_KEYWORDS

### DIFF
--- a/dbusaddons/fcitxqtconnection.cpp
+++ b/dbusaddons/fcitxqtconnection.cpp
@@ -271,7 +271,7 @@ void FcitxQtConnectionPrivate::createConnection() {
                               "org.freedesktop.DBus.Local", "Disconnected",
                               this, SLOT(dbusDisconnected()));
         m_connectedOnce = true;
-        emit q->connected();
+        Q_EMIT q->connected();
     }
 }
 
@@ -314,7 +314,7 @@ void FcitxQtConnectionPrivate::cleanUp() {
      * and startConnection can be called in slot
      */
     if (doemit)
-        emit q->disconnected();
+        Q_EMIT q->disconnected();
 }
 
 bool FcitxQtConnectionPrivate::isConnected() {

--- a/guiwrapper/mainwindow.h
+++ b/guiwrapper/mainwindow.h
@@ -35,7 +35,7 @@ public:
     explicit MainWindow(FcitxQtConfigUIWidget *pluginWidget,
                         QWidget *parent = 0);
     virtual ~MainWindow();
-public slots:
+public Q_SLOTS:
     void changed(bool changed);
     void clicked(QAbstractButton *button);
     void connected();

--- a/guiwrapper/wrapperapp.h
+++ b/guiwrapper/wrapperapp.h
@@ -32,7 +32,7 @@ public:
     WrapperApp(int &argc, char **argv);
     virtual ~WrapperApp();
 
-private slots:
+private Q_SLOTS:
     void errorExit();
 
 private:

--- a/platforminputcontext/fcitxinputcontextproxy.cpp
+++ b/platforminputcontext/fcitxinputcontextproxy.cpp
@@ -195,7 +195,7 @@ void FcitxInputContextProxy::createInputContextFinished() {
 
     delete m_createInputContextWatcher;
     m_createInputContextWatcher = nullptr;
-    emit inputContextCreated();
+    Q_EMIT inputContextCreated();
 }
 
 bool FcitxInputContextProxy::isValid() const {
@@ -205,7 +205,7 @@ bool FcitxInputContextProxy::isValid() const {
 
 void FcitxInputContextProxy::forwardKeyWrapper(uint keyval, uint state,
                                                int type) {
-    emit forwardKey(keyval, state, type == 1);
+    Q_EMIT forwardKey(keyval, state, type == 1);
 }
 
 void FcitxInputContextProxy::updateFormattedPreeditWrapper(
@@ -217,7 +217,7 @@ void FcitxInputContextProxy::updateFormattedPreeditWrapper(
         item.setFormat(item.format() ^ underlineBit);
     }
 
-    emit updateFormattedPreedit(list, cursorpos);
+    Q_EMIT updateFormattedPreedit(list, cursorpos);
 }
 
 QDBusPendingReply<> FcitxInputContextProxy::focusIn() {

--- a/platforminputcontext/fcitxinputcontextproxy.h
+++ b/platforminputcontext/fcitxinputcontextproxy.h
@@ -53,7 +53,7 @@ public:
     QDBusPendingReply<> setSurroundingTextPosition(uint cursor, uint anchor);
     void setDisplay(const QString &display);
 
-signals:
+Q_SIGNALS:
     void commitString(const QString &str);
     void currentIM(const QString &name, const QString &uniqueName,
                    const QString &langCode);
@@ -63,7 +63,7 @@ signals:
                                 int cursorpos);
     void inputContextCreated();
 
-private slots:
+private Q_SLOTS:
     void availabilityChanged();
     void createInputContext();
     void createInputContextFinished();

--- a/platforminputcontext/fcitxwatcher.cpp
+++ b/platforminputcontext/fcitxwatcher.cpp
@@ -109,7 +109,7 @@ QString FcitxWatcher::service() const {
 void FcitxWatcher::setAvailability(bool availability) {
     if (m_availability != availability) {
         m_availability = availability;
-        emit availabilityChanged(m_availability);
+        Q_EMIT availabilityChanged(m_availability);
     }
 }
 

--- a/platforminputcontext/fcitxwatcher.h
+++ b/platforminputcontext/fcitxwatcher.h
@@ -45,10 +45,10 @@ public:
     QDBusConnection connection() const;
     QString service() const;
 
-signals:
+Q_SIGNALS:
     void availabilityChanged(bool);
 
-private slots:
+private Q_SLOTS:
     void dbusDisconnected();
     void socketFileChanged();
     void imChanged(const QString &service, const QString &oldOwner,

--- a/platforminputcontext/qfcitxplatforminputcontext.h
+++ b/platforminputcontext/qfcitxplatforminputcontext.h
@@ -240,7 +240,7 @@ private:
     QScopedPointer<struct xkb_compose_state, XkbComposeStateDeleter>
         m_xkbComposeState;
     QLocale m_locale;
-private slots:
+private Q_SLOTS:
     void processKeyEventFinished(QDBusPendingCallWatcher *);
 };
 

--- a/quickphrase-editor/editor.h
+++ b/quickphrase-editor/editor.h
@@ -50,14 +50,14 @@ public:
 
     void loadFileList();
 
-public slots:
+public Q_SLOTS:
     void batchEditAccepted();
     void removeFileTriggered();
     void addFileTriggered();
     void refreshListTriggered();
     void changeFile(int);
 
-private slots:
+private Q_SLOTS:
     void addWord();
     void batchEditWord();
     void deleteWord();

--- a/quickphrase-editor/model.cpp
+++ b/quickphrase-editor/model.cpp
@@ -116,13 +116,13 @@ bool QuickPhraseModel::setData(const QModelIndex &index, const QVariant &value,
     if (index.column() == 0) {
         m_list[index.row()].first = value.toString();
 
-        emit dataChanged(index, index);
+        Q_EMIT dataChanged(index, index);
         setNeedSave(true);
         return true;
     } else if (index.column() == 1) {
         m_list[index.row()].second = value.toString();
 
-        emit dataChanged(index, index);
+        Q_EMIT dataChanged(index, index);
         setNeedSave(true);
         return true;
     } else
@@ -262,7 +262,7 @@ void QuickPhraseModel::saveFinished() {
 void QuickPhraseModel::setNeedSave(bool needSave) {
     if (m_needSave != needSave) {
         m_needSave = needSave;
-        emit needSaveChanged(m_needSave);
+        Q_EMIT needSaveChanged(m_needSave);
     }
 }
 } // namespace fcitx

--- a/quickphrase-editor/model.h
+++ b/quickphrase-editor/model.h
@@ -54,10 +54,10 @@ public:
     void saveData(QTextStream &dev);
     bool needSave();
 
-signals:
+Q_SIGNALS:
     void needSaveChanged(bool m_needSave);
 
-private slots:
+private Q_SLOTS:
     void loadFinished();
     void saveFinished();
 


### PR DESCRIPTION
This allows building fcitx-qt5 with QT_NO_KEYWORDS set. Qt sets some keywords that conflict with other libraries, when building fcitx-qt5 as part of such a project. Of course, it's possible to not to passthrough it to fcitx-qt5, maybe you can consider this useful though. You can set QT_NO_KEYWORDS in target_compile_definitions in order to avoid new uses of keywords.