### PR TITLE
FcitxQtKeySequenceWidget: fix meta key handling

### DIFF
--- a/widgetsaddons/fcitxqtkeysequencewidget.cpp
+++ b/widgetsaddons/fcitxqtkeysequencewidget.cpp
@@ -394,6 +394,11 @@ void FcitxQtKeySequenceButton::keyPressEvent(QKeyEvent *e) {
     switch (keyQt) {
     case Qt::Key_AltGr: // or else we get unicode salad
         return;
+    case Qt::Key_Super_L:
+    case Qt::Key_Super_R:
+        // Qt doesn't properly recognize Super_L/Super_R as MetaModifier
+        d->modifierKeys |= Qt::MetaModifier;
+        Q_FALLTHROUGH();
     case Qt::Key_Shift:
     case Qt::Key_Control:
     case Qt::Key_Alt:


### PR DESCRIPTION
fcitx-kcm refuses to accept shortcuts like Meta-Space without this patch.
It also gives Unicode salad when only Meta key is pressed.

The code was sourced from the latest KDE equivalent of this function,
which is KeySequenceRecorderPrivate::handleKeyPress from KGuiAddons.